### PR TITLE
Remove excess info

### DIFF
--- a/models/device_output.js
+++ b/models/device_output.js
@@ -12,9 +12,9 @@ module.exports = (db, Validator, DeviceExperiment) => {
                 = _Validator.getWhereAndQueryParamList(data, POSSIBLE_QUERY_PARAMS);
             return new Promise((resolve, reject) => {
                 _db.query(`SELECT *, device_outputs.* FROM device_outputs
-                        INNER JOIN output_types on device_outputs.output_type_id = output_types.id
-                        INNER JOIN sanitized_users on (device_outputs.device_id = sanitized_users.id)
-                        INNER JOIN experiments on (device_outputs.experiment_id = experiments.id)
+                        ${'output_type_id' in data ? '' : 'INNER JOIN output_types on device_outputs.output_type_id = output_types.id'}
+                        ${'device_id' in data ? '' : 'INNER JOIN sanitized_users on (device_outputs.device_id = sanitized_users.id)'}
+                        ${'experiment_id' in data ? '' : 'INNER JOIN experiments on (device_outputs.experiment_id = experiments.id)'}
                         WHERE device_outputs.deleted_at = 0
                         ${additionalWhere}
                         ORDER BY device_outputs.timestamp ASC`, queryParamList)

--- a/models/device_output.js
+++ b/models/device_output.js
@@ -36,7 +36,6 @@ module.exports = (db, Validator, DeviceExperiment) => {
                     .then((result) => {
                         return _db.query(`SELECT *, device_outputs.* FROM device_outputs
                             INNER JOIN output_types on (device_outputs.output_type_id = output_types.id)
-                            INNER JOIN sanitized_users on (device_outputs.device_id = sanitized_users.id)
                             INNER JOIN experiments on (device_outputs.experiment_id = experiments.id)
                             WHERE device_outputs.device_id = $1 and device_outputs.deleted_at = 0
                             ORDER BY device_outputs.timestamp ASC`, [result.id])
@@ -60,7 +59,6 @@ module.exports = (db, Validator, DeviceExperiment) => {
                         return _db.query(`SELECT *, device_outputs.* FROM device_outputs
                             INNER JOIN output_types on (device_outputs.output_type_id = output_types.id)
                             INNER JOIN sanitized_users on (device_outputs.device_id = sanitized_users.id)
-                            INNER JOIN experiments on (device_outputs.experiment_id = experiments.id)
                             WHERE device_outputs.experiment_id = $1 and device_outputs.deleted_at = 0
                             ORDER BY device_outputs.timestamp ASC`, [result.id])
                     })
@@ -80,8 +78,6 @@ module.exports = (db, Validator, DeviceExperiment) => {
                     .then((result) => {
                         return _db.query(`SELECT *, device_outputs.* FROM device_outputs
                             INNER JOIN output_types on (device_outputs.output_type_id = output_types.id)
-                            INNER JOIN sanitized_users on (device_outputs.device_id = sanitized_users.id)
-                            INNER JOIN experiments on (device_outputs.experiment_id = experiments.id)
                             WHERE device_outputs.device_id = $1 and device_outputs.experiment_id = $2 and device_outputs.deleted_at = 0
                             ORDER BY device_outputs.timestamp ASC`, [result.device_id, result.experiment_id])
                     })


### PR DESCRIPTION
Don't need to include all this information if the id values are passed in the request. Since the values will be constant for all rows, we can exclude them altogether.